### PR TITLE
Prepare for Kubernetes donation

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  # TODO: in your repo created from this template, you should replace the
-  # github-admin-team with a list of project owners, see the doc linked above.
-  - github-admin-team
+  - artifact-approvers
+reviewers:
+  - artifact-reviewers
+labels:
+  - area/artifacts

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,72 @@
 # See the OWNERS docs at https://go.k8s.io/owners#owners_aliases
 
 aliases:
+  # Maintainers
+  artifact-approvers:
+    - bartsmykla # WG K8s Infra Lead
+    - dims # WG K8s Infra Lead
+    - hasheddan # subproject owner / Release Manager / SIG Technical Lead
+    - justaugustus # subproject owner / Release Manager / SIG Chair
+    - listx # Container image promoter admin
+    - saschagrunert # subproject owner / Release Manager / SIG Chair
+    - spiffxp # WG K8s Infra Lead
+    - thockin # Container image promoter admin
+  artifact-reviewers:
+    - bartsmykla # WG K8s Infra Lead
+    - dims # WG K8s Infra Lead
+    - hasheddan # subproject owner / Release Manager / SIG Technical Lead
+    - justaugustus # subproject owner / Release Manager / SIG Chair
+    - listx # Container image promoter admin
+    - saschagrunert # subproject owner / Release Manager / SIG Chair
+    - spiffxp # WG K8s Infra Lead
+    - thockin # Container image promoter admin
+
+  # Synced from k/k8s.io (last updated: 11/22/20)
+  build-image-approvers:
+    - BenTheElder
+    - cblecker
+    - dims
+    - justaugustus
+    - listx
+  build-image-reviewers:
+    - BenTheElder
+    - cblecker
+    - dims
+    - justaugustus
+    - listx
+  cip-approvers:
+    - justaugustus
+    - justinsb
+    - listx
+    - thockin
+  cip-reviewers:
+    - justaugustus
+    - justinsb
+    - listx
+    - thockin
+  release-engineering-approvers:
+    - alejandrox1 # SIG Technical Lead
+    - cpanato # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # subproject owner / Release Manager / SIG Technical Lead
+    - idealhack # Release Manager
+    - justaugustus # subproject owner / Release Manager / SIG Chair
+    - puerco # Release Manager
+    - saschagrunert # subproject owner / Release Manager / SIG Chair
+    - tpepper # subproject owner
+    - xmudrii # Release Manager
+  release-engineering-reviewers:
+    - alejandrox1 # SIG Technical Lead
+    - cpanato # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # subproject owner / Release Manager / SIG Technical Lead
+    - idealhack # Release Manager
+    - justaugustus # subproject owner / Release Manager / SIG Chair
+    - puerco # Release Manager
+    - saschagrunert # subproject owner / Release Manager / SIG Chair
+    - tpepper # subproject owner
+    - xmudrii # Release Manager
+
   # Synced from k/community (last updated: 11/22/20)
   sig-api-machinery-leads:
     - deads2k

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,14 +1,189 @@
 # See the OWNERS docs at https://go.k8s.io/owners#owners_aliases
 
 aliases:
-  # TODO: remove this alias, it will go stale in your repo, and in your repo
-  # you should have your own set of approvers (see OWNERS)
-  # in the original template repo, we must maintain this list to approve changes
-  # to the template itself
-  github-admin-team:
+  # Synced from k/community (last updated: 11/22/20)
+  sig-api-machinery-leads:
+    - deads2k
+    - fedebongio
+    - lavalamp
+  sig-apps-leads:
+    - janetkuo
+    - kow3ns
+    - mattfarina
+    - prydonius
+  sig-architecture-leads:
+    - derekwaynecarr
+    - dims
+    - johnbelamaric
+  sig-auth-leads:
+    - deads2k
+    - enj
+    - liggitt
+    - mikedanese
+    - tallclair
+  sig-autoscaling-leads:
+    - gjtempleton
+    - mwielgus
+  sig-cli-leads:
+    - pwittrock
+    - seans3
+    - soltysh
+  sig-cloud-provider-leads:
+    - andrewsykim
+    - cheftako
+  sig-cluster-lifecycle-leads:
+    - fabriziopandini
+    - justinsb
+    - neolit123
+    - timothysc
+  sig-contributor-experience-leads:
+    - castrojo
     - cblecker
-    - fejta
-    - idvoretskyi
     - mrbobbytables
     - nikhita
+  sig-docs-leads:
+    - irvifa
+    - jimangel
+    - kbarnard10
+    - kbhawkey
+    - onlydole
+    - sftim
+  sig-instrumentation-leads:
+    - brancz
+    - dashpole
+    - ehashman
+    - logicalhan
+  sig-multicluster-leads:
+    - jeremyot
+    - pmorie
+  sig-network-leads:
+    - caseydavenport
+    - dcbw
+    - thockin
+  sig-node-leads:
+    - dchen1107
+    - derekwaynecarr
+  sig-release-leads:
+    - alejandrox1
+    - hasheddan
+    - justaugustus
+    - saschagrunert
+  sig-scalability-leads:
+    - mm4tt
+    - shyamjvs
+    - wojtek-t
+  sig-scheduling-leads:
+    - Huang-Wei
+    - ahg-g
+  sig-security-leads:
+    - iancoldwater
+    - tabbysable
+  sig-service-catalog-leads:
+    - jberkhahn
+    - jhvhs
+  sig-storage-leads:
+    - jsafrane
+    - msau42
+    - saad-ali
+    - xing-yang
+  sig-testing-leads:
+    - BenTheElder
     - spiffxp
+    - stevekuznetsov
+  sig-ui-leads:
+    - floreks
+    - jeefy
+    - maciaszczykm
+  sig-usability-leads:
+    - hpandeycodeit
+    - tashimi
+  sig-windows-leads:
+    - benmoss
+    - ddebroy
+    - marosset
+    - michmike
+  wg-api-expression-leads:
+    - apelisse
+    - kwiesmueller
+  wg-component-standard-leads:
+    - mtaufen
+    - stealthybox
+  wg-data-protection-leads:
+    - xing-yang
+    - yuxiangqian
+  wg-iot-edge-leads:
+    - cantbewong
+    - cindyxing
+    - dejanb
+  wg-k8s-infra-leads:
+    - bartsmykla
+    - dims
+    - spiffxp
+  wg-multitenancy-leads:
+    - srampal
+    - tashimi
+  wg-naming-leads:
+    - celestehorgan
+    - jdumars
+    - justaugustus
+    - zacharysarah
+  wg-policy-leads:
+    - ericavonb
+    - hannibalhuang
+  wg-reliability-leads:
+    - deads2k
+    - stevekuznetsov
+    - wojtek-t
+  ug-big-data-leads:
+    - erikerlandson
+    - foxish
+    - liyinan926
+  ug-vmware-users-leads:
+    - brysonshepherd
+    - cantbewong
+    - mylesagray
+    - phenixblue
+  committee-code-of-conduct:
+    - AevaOnline
+    - celestehorgan
+    - karenhchu
+    - tashimi
+    - tpepper
+  committee-product-security:
+    - cjcullen
+    - cji
+    - joelsmith
+    - lukehinds
+    - micahhausler
+    - swamymsft
+    - tallclair
+  committee-steering:
+    - cblecker
+    - derekwaynecarr
+    - dims
+    - liggitt
+    - mrbobbytables
+    - nikhita
+    - parispittman
+## BEGIN CUSTOM CONTENT
+  provider-aws:
+    - d-nishi
+    - justinsb
+    - kris-nova
+  provider-azure:
+    - craiglpeters
+    - justaugustus
+    - feiskyer
+    - khenidak
+  provider-gcp:
+    - abgworrall
+  provider-ibmcloud:
+    - spzala
+  provider-openstack:
+    - chrigl
+    - lingxiankong
+    - ramineni
+  provider-vmware:
+    - cantbewong
+    - frapposelli
+## END CUSTOM CONTENT

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,5 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-bob
-alice
+alejandrox1
+hasheddan
+justaugustus
+saschagrunert

--- a/registries/k8s.gcr.io/images/k8s-staging-releng/OWNERS
+++ b/registries/k8s.gcr.io/images/k8s-staging-releng/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/registries/k8s.gcr.io/manifests/OWNERS
+++ b/registries/k8s.gcr.io/manifests/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - artifact-approvers
+reviewers:
+  - artifact-reviewers
+labels:
+  - area/artifacts

--- a/registries/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
+++ b/registries/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-releng is k8s-infra-staging-releng@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-releng
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/releng
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/releng
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/releng
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/stores/artifacts.k8s.io/files/k8s-staging-releng/OWNERS
+++ b/stores/artifacts.k8s.io/files/k8s-staging-releng/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/stores/artifacts.k8s.io/manifests/OWNERS
+++ b/stores/artifacts.k8s.io/manifests/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - artifact-approvers
+reviewers:
+  - artifact-reviewers
+labels:
+  - area/artifacts

--- a/stores/artifacts.k8s.io/manifests/k8s-staging-releng/promoter-manifest.yaml
+++ b/stores/artifacts.k8s.io/manifests/k8s-staging-releng/promoter-manifest.yaml
@@ -1,0 +1,6 @@
+# google group for gcr.io/k8s-staging-releng is k8s-infra-staging-releng@kubernetes.io
+filestores:
+- base: gs://k8s-staging-releng/releases/
+  src: true
+- base: gs://k8s-artifacts-prod/files/releng/releases/
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Spawned from @thockin suggestion in https://kubernetes.slack.com/archives/CCK68P2Q2/p1603987072094400.

Will work on the donation discussion this week.

- SECURITY_CONTACTS: Add SIG Release leads
- OWNERS: Sync aliases from k/community
- OWNERS: Add maintainers (RelEng owners, WG K8s Infra leads, CIP admins)
- OWNERS: Populate manifest and releng directory owners
- releng: Add promoter manifests

Current directory structure:

```console
├── code-of-conduct.md
├── CONTRIBUTING.md
├── LICENSE
├── OWNERS
├── OWNERS_ALIASES
├── README.md
├── registries
│   └── k8s.gcr.io
│       ├── images
│       │   └── k8s-staging-releng
│       │       └── OWNERS
│       └── manifests
│           ├── k8s-staging-releng
│           │   └── promoter-manifest.yaml
│           └── OWNERS
├── RELEASE.md
├── SECURITY_CONTACTS
├── SECURITY.md
└── stores
    └── artifacts.k8s.io
        ├── files
        │   └── k8s-staging-releng
        │       └── OWNERS
        └── manifests
            ├── k8s-staging-releng
            │   └── promoter-manifest.yaml
            └── OWNERS
```